### PR TITLE
Properly convert QoS value

### DIFF
--- a/ios/RCTMqtt/Mqtt.m
+++ b/ios/RCTMqtt/Mqtt.m
@@ -171,7 +171,7 @@
 - (void) publish:(NSString *) topic data:(NSData *)data qos:(NSNumber *)qos retain:(BOOL) retain {
     [self.manager sendData:data
                      topic:topic
-                       qos:(MQTTQosLevel)qos
+                       qos:[qos intValue]
                     retain:retain];
     //[data dataUsingEncoding:NSUTF8StringEncoding]
 }


### PR DESCRIPTION
Casting doesn't yield the appropriate value.

As a result, it would always send QoS 2 even if you pass  QoS 1.