### PR TITLE
Bridge data types

### DIFF
--- a/ios/RCTMqtt/RCTMqtt.m
+++ b/ios/RCTMqtt/RCTMqtt.m
@@ -85,27 +85,27 @@ RCT_EXPORT_METHOD(createClient:(NSDictionary *) options
     resolve([NSNumber numberWithInt:clientRef]);
     
 }
-RCT_EXPORT_METHOD(connect:(int) clientRef) {
+RCT_EXPORT_METHOD(connect:(nonnull NSNumber *) clientRef) {
     
-    [[[self clients] objectForKey:[NSNumber numberWithInt:clientRef]] connect];
-    
-}
-
-
-RCT_EXPORT_METHOD(disconnect:(int) clientRef) {
-    [[[self clients] objectForKey:[NSNumber numberWithInt:clientRef]] disconnect];
-}
-
-RCT_EXPORT_METHOD(subscribe:(int) clientRef topic:(NSString *)topic qos:(int)qos) {
-    [[[self clients] objectForKey:[NSNumber numberWithInt:clientRef]] subscribe:topic qos:[NSNumber numberWithInt:qos]];
+    [[[self clients] objectForKey:clientRef] connect];
     
 }
 
-RCT_EXPORT_METHOD(publish:(int) clientRef topic:(NSString *)topic data:(NSString*)data qos:(int)qos retain:(int)retain) {
-    [[[self clients] objectForKey:[NSNumber numberWithInt:clientRef]] publish:topic
-                                                                         data:[data dataUsingEncoding:NSUTF8StringEncoding]
-                                                                          qos:[NSNumber numberWithInt:qos]
-                                                                       retain:(BOOL)retain];
+
+RCT_EXPORT_METHOD(disconnect:(nonnull NSNumber *) clientRef) {
+    [[[self clients] objectForKey:clientRef] disconnect];
+}
+
+RCT_EXPORT_METHOD(subscribe:(nonnull NSNumber *) clientRef topic:(NSString *)topic qos:(nonnull NSNumber *)qos) {
+    [[[self clients] objectForKey:clientRef] subscribe:topic qos:qos]];
+    
+}
+
+RCT_EXPORT_METHOD(publish:(nonnull NSNumber *) clientRef topic:(NSString *)topic data:(NSString*)data qos:(nonnull NSNumber *)qos retain:(BOOL)retain) {
+    [[[self clients] objectForKey:clientRef] publish:topic
+                                                data:[data dataUsingEncoding:NSUTF8StringEncoding]
+                                                 qos:qos
+                                              retain:retain];
 
 }
 


### PR DESCRIPTION
There's no point in passing an `int` when you can just pass a `boolean` through the bridge just fine.

Also, React Native is able to convert numbers to `NSNumber` automatically.

__Edit__:

I noticed you're using `int`s as the value being passed through bridge throughout.
Is there any reason why you're using `int`s instead of `NSNumber`s?