### PR TITLE
<service> tag inside <application> tag

### DIFF
--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -3,7 +3,8 @@
 	<uses-permission android:name="android.permission.INTERNET" />
 	<uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
 	<uses-permission android:name="android.permission.READ_PHONE_STATE" />
-
+	<application>
 	<service android:name="org.eclipse.paho.android.service.MqttService" >
 	</service>
+	</application>
 </manifest>


### PR DESCRIPTION
as per the latest android manifest rules, <service> tag should be kept inside <application> tag, AAPT2 displays an error if this tag is misplaced.